### PR TITLE
productionGzip is conditional & defaults to false

### DIFF
--- a/template/config/index.js
+++ b/template/config/index.js
@@ -11,9 +11,9 @@ module.exports = {
     productionSourceMap: true,
     // Gzip off by default as many popular static hosts such as
     // Surge or Netlify already gzip all static assets for you.
-    // Before setting to `true`, make sure to:
-    // npm install --save-dev compression-webpack-plugin
-    productionGzip: true,
+    // Also, Android has issues building with gzip true
+    // `npm run build --gzip` to build gzipped assets
+    productionGzip: process.env.npm_config_gzip || false,
     productionGzipExtensions: ['js', 'css'],
     // Run the build command with an extra argument to
     // View the bundle analyzer report after build finishes:


### PR DESCRIPTION
to get gzipped assets, build with

```bash
npm run build --gzip
```

Fixes #16 