### PR TITLE
Fix for live reload in the developer app

### DIFF
--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -62,7 +62,7 @@ var webpackConfig = merge(baseWebpackConfig, {
       minify: {
         removeComments: true,
         collapseWhitespace: false,
-        removeAttributeQuotes: true
+        removeAttributeQuotes: false
         // more options:
         // https://github.com/kangax/html-minifier#options-quick-reference
       },

--- a/template/src/index.html
+++ b/template/src/index.html
@@ -43,7 +43,7 @@
   <body>
     <div id="app"></div>
     <noscript>This is your fallback content in case JavaScript fails to load.</noscript>
-    <script src="cordova.js"></script>
+    <script type="text/javascript" src="cordova.js"></script>
     <!-- Todo: only include in production -->
     <%= htmlWebpackPlugin.options.serviceWorkerLoader %>
     <!-- built files will be auto injected -->


### PR DESCRIPTION
- removed `removeAttributeQuotes` minification
- changed `cordova.js` script tag to exactly match the one the dev app
  tries to replace
```
<script type="text/javascript" src="cordova.js"></script>
```

Fixes #24